### PR TITLE
issue 68: Downloading CSV fails

### DIFF
--- a/src/arcrest/manageorg/_content.py
+++ b/src/arcrest/manageorg/_content.py
@@ -684,7 +684,7 @@ def %s(self):
         if self.type in ["Shapefile", "CityEngine Web Scene", "Web Scene", "KML",
                          "Code Sample",
                          "Code Attachment", "Operations Dashboard Add In",
-                         "CSV", "CAD Drawing", "Service Definition",
+                         "CSV", "CSV Collection", "CAD Drawing", "Service Definition",
                          "Microsoft Word", "Microsoft Powerpoint",
                          "Microsoft Excel", "PDF", "Image",
                          "Visio Document", "iWork Keynote", "iWork Pages",


### PR DESCRIPTION
Downloading a CSV fails from a feature service. The method itemData on
_content.py has a  type check for "CSV", but not for "CSV Collection".
When I add "CSV Collection" to the list, the csv downloads correctly.