### PR TITLE
Fixed editProtocol method of class Clusters

### DIFF
--- a/src/arcrest/manageags/_clusters.py
+++ b/src/arcrest/manageags/_clusters.py
@@ -369,7 +369,7 @@ class Cluster(BaseAGSServer):
         url = self._url + "/editProtocol"
         params = {
             "f" : "json",
-            "tcpClusterPort" : str(clusterProtocolObj)
+            "tcpClusterPort" : str(clusterProtocolObj.value['tcpClusterPort'])
         }
         return self._do_post(url=url,
                              param_dict=params,

--- a/src/arcrest/manageags/_security.py
+++ b/src/arcrest/manageags/_security.py
@@ -69,7 +69,7 @@ class Security(BaseAGSServer):
             If the name of the role exists in the role store, an error will
             be returned.
             Input:
-               name - The name of the role. The name must be unique in the
+               rolename - The name of the role. The name must be unique in the
                       role store.
                description - An optional field to add comments or a
                              description for the role.
@@ -78,7 +78,7 @@ class Security(BaseAGSServer):
         """
         params = {
             "f" : "json",
-            "name" : name,
+            "rolename" : name,
             "description" : description
         }
         aURL = self._url + "/roles/add"


### PR DESCRIPTION
In `_clusters.py`, edited `editProtocol()` method to use the correct `tcpClusterPort` element (string from integer instead of dictionary).