### PR TITLE
Add domains to fields in an existing hosted service

### DIFF
--- a/samples/HostedFeatureServiceAdmin/addDomainToHostedFeatureService.py
+++ b/samples/HostedFeatureServiceAdmin/addDomainToHostedFeatureService.py
@@ -1,0 +1,48 @@
+"""
+    Adds a domain to the specified field in any layer matching the name in all feature services
+    without republishing
+"""
+import arcrest
+
+if __name__ == "__main__":
+    url = "https://<url to spatial data store>/ArcGIS/rest/admin"
+    username = "<user name>"
+    password = "<password>"
+    featureLayerNames = ["layername"] # must be all lowercase
+    definition = {
+        "fields": [
+            {
+                "name": "Type",
+                "domain": {
+                    "type": "codedValue",
+                    "name": "Type",
+                    "codedValues": [
+                        {
+                            "name": "Option A",
+                            "code": "type_a"
+                        },
+                        {
+                            "name": "Option B",
+                            "code": "type_b"
+                        },
+                        {
+                            "name": "Option C",
+                            "code": "type_c"
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    sh = arcrest.AGOLTokenSecurityHandler(username, password)
+    agolServices = arcrest.hostedservice.Services(url, securityHandler=sh)
+    for service in agolServices.services:
+        if not service.layers is None:
+            print service.url
+            for lyr in service.layers:
+                print lyr.name    
+                
+                if lyr.name.lower() in featureLayerNames:
+                    print lyr.updateDefinition(definition)
+                    #  Output: {'success': True}

--- a/src/arcrest/hostedservice/service.py
+++ b/src/arcrest/hostedservice/service.py
@@ -198,7 +198,7 @@ class Services(BaseAGOLClass):
                     name = item['serviceName']
                     typefs = item['type']
 
-                surl = url + r"/%s.%s" % (name,
+                surl = url + r"/%s/%s" % (name,
                                            typefs)
                 self._services.append(
                     AdminFeatureService(url=surl,


### PR DESCRIPTION
Adding domains to feature services makes a nice editor experience by providing a picklist of choices rather than freeform text entry especially when using apps like Collector for ArcGIS. I often need to add or update domains after creating a service. This sample makes that much easier.

When creating this sample, I noticed the URL to hosted services was using a `.` instead of a `/` so the URLs looked like `<serviceUrl>.FeatureServer` which caused ArcREST to fail.