### PR TITLE
Fixed issue where multipart add item calls would fail

### DIFF
--- a/src/arcrest/manageorg/_content.py
+++ b/src/arcrest/manageorg/_content.py
@@ -1684,11 +1684,11 @@ class UserItem(BaseAGOLClass):
                                 securityHandler=self._securityHandler,
                                 proxy_port=self._proxy_port,
                                 proxy_url=self._proxy_url)
-            res = self.status(jobId=res['id'])
+            res = self.status()
             import time
             while res['status'].lower() in ["partial", "processing"]:
                 time.sleep(2)
-                res = self.status(jobId=res['id'])
+                res = self.status()
             return res
         else:
             return self._do_post(url=url,


### PR DESCRIPTION
I was experiencing errors when adding an item using the multipart add.  It looked like calling status() with a jobId parameter after committing the job would result in a failure and the correct item id would not be returned.  I removed the jobId parameter from the status call and the addItem method returned as expected.