### PR TITLE
Update add_item.py

### DIFF
--- a/samples/add_item.py
+++ b/samples/add_item.py
@@ -82,9 +82,10 @@ def main():
             itemParams.tags = "tags"
             itemParams.snippet = "Test File"
             itemParams.typeKeywords = "Data,Image,png"
-            itemParams.filename = upload_file
+            #itemParams.filename = upload_file
             item = userInfo.addItem(
                 itemParameters=itemParams,
+                filePath= upload_file,
                 overwrite=True,
                 relationshipType=None,
                 originItemId=None,


### PR DESCRIPTION
For adding an item of type "Image" or " Tile Package" (tested with those, but probably others) , a file path parameter is needed.  ItemParameter fileName is not being used.