### PR TITLE
BaseWebOperations.__processHandler bugfixes

### DIFF
--- a/src/arcrest/web/_base.py
+++ b/src/arcrest/web/_base.py
@@ -142,8 +142,9 @@ if six.PY2:
             if securityHandler is None:
                 from cookielib import CookieJar
                 cj = CookieJar()
-            elif securityHandler.method.lower() == "token":
-                param_dict['token'] = securityHandler.token
+            elif securityHandler.method.lower() == "token" or securityHandler.method.lower() == "oauth":
+                if param_dict is not None: 
+                    param_dict['token'] = securityHandler.token
                 if hasattr(securityHandler, 'cookiejar'):
                     cj = securityHandler.cookiejar
                 if hasattr(securityHandler, 'handler'):


### PR DESCRIPTION
Issues addressed: 
1. __processHandler failing to process securityHandler instance of OAuthSecurityHandler type
2. BaseWebOperations.__processHandler generates NoneType assignment exception when a call is made by BaseWebOperations._download_file with param_dict = None