### PR TITLE
Update _base.py to ascii-encode URL

### DIFF
--- a/src/arcrest/web/_base.py
+++ b/src/arcrest/web/_base.py
@@ -400,7 +400,7 @@ if six.PY2:
                 handlers.append(urllib2.HTTPCookieProcessor(cj))
             opener = urllib2.build_opener(*handlers)
             urllib2.install_opener(opener)
-            request = urllib2.Request(url)
+            request = urllib2.Request(url.encode('ascii'))
             request.add_header('User-agent', self._useragent)
             request.add_header('Content-type', content_type)
             request.add_header('Content-length', len(body))


### PR DESCRIPTION
I had an issue with addItem running from ArcMap where it would fail to POST the form-data as it expected the data to be utf-encoded as the initial Request was created with a utf URL. I believe this change doesn't break anything else (all Portal URLs are ascii, generally?) and lets `_post_multipart` work from within ArcMap or ArcCatalog.

Open to thoughts of a better way to handle it. Also I'm not really sure how it works differently in 3.x as the code for _post_multipart is substantially different there.