### PR TITLE
arcresthelper six

### DIFF
--- a/src/arcresthelper/securityhandlerhelper.py
+++ b/src/arcresthelper/securityhandlerhelper.py
@@ -5,8 +5,8 @@ import arcrest
 from arcrest.manageags import AGSAdministration
 from arcrest.manageorg import Administration
 from packages import six
-import six.moves.urllib as urllib
-from six.moves.urllib.error import HTTPError
+import packages.six.moves.urllib as urllib
+from packages.six.moves.urllib.error import HTTPError
 import os
 import common
 import copy


### PR DESCRIPTION
fix for relative import of `arcresthelper`, i.e., not installing anything