### PR TITLE
Add condition to show error message if connection is not valid

### DIFF
--- a/tools/src/append_fc_to_fs.py
+++ b/tools/src/append_fc_to_fs.py
@@ -171,7 +171,9 @@ def main(*argv):
             else:
                 outputPrinter(message="\tFeature Service with id %s was not found" % fsId,typeOfMessage='error')
                 arcpy.SetParameterAsText(9, "false")
-
+        else:
+            outputPrinter(message=fst.message, typeOfMessage="error")
+            arcpy.SetParameterAsText(9, "false")
     except arcpy.ExecuteError:
         line, filename, synerror = trace()
         outputPrinter(message="error on line: %s" % line,typeOfMessage='error')


### PR DESCRIPTION
+ When connection is not valid (e.g. user is not connected) the tool
runs without any error, giving the impression that everything went fine.