### PR TITLE
import _meteor

### DIFF
--- a/src/_meteor/__init__.py
+++ b/src/_meteor/__init__.py
@@ -5,7 +5,7 @@ from .connection import SiteConnection as Connection
 from . import common
 from . import service
 from .portal import Portal
-from .server.catalog import AGSCatalog
+# from .server.catalog import AGSCatalog
 
 __version__ = "4.0.0"
 __all__ = ['service',

--- a/src/_meteor/common/geometry/_polyline.py
+++ b/src/_meteor/common/geometry/_polyline.py
@@ -77,7 +77,7 @@ class Polyline(AbstractGeometry):
                 del path
         elif arcpyFound and \
              isinstance(paths, arcpy.Polyline):
-            print 'arcpy.Polyline'
+            print ('arcpy.Polyline')
         elif isinstance(paths, Point):
             return paths
         return _geoms
@@ -160,7 +160,7 @@ class Polyline(AbstractGeometry):
                                                   x2=path[1][0], y2=path[1][1])
                 else:
                     for pt in range(len(path)):
-                        print pt, pt+1, len(path)
+                        print (pt, pt+1, len(path))
                         if pt + 1 < len(path):
                             distance += calculateDistance(
                                 x1=path[pt][0], y1=path[pt][1],

--- a/src/_meteor/portal/__init__.py
+++ b/src/_meteor/portal/__init__.py
@@ -3,5 +3,5 @@
 """
 from __future__ import absolute_import
 from ._site import Portal
-from . import opendata
+# from . import opendata
 __all__ = ['Portal', 'opendata']

--- a/src/_meteor/portal/administration/administration.py
+++ b/src/_meteor/portal/administration/administration.py
@@ -7,7 +7,7 @@ from .._base import BasePortal
 import json
 from . import _portals, _community, _content, _oauth2
 from ..hostedservice import Services
-from ..enrichment import GeoEnrichment
+# from ..enrichment import GeoEnrichment
 from ...server import AGSAdministration
 from ...common.packages.six.moves.urllib_parse import urlparse, urlunparse
 

--- a/src/_meteor/server/__init__.py
+++ b/src/_meteor/server/__init__.py
@@ -2,7 +2,7 @@
 Server Control Package
 """
 from __future__ import absolute_import
-from .server.ags import Catalog as AGSCatalog
+# from .server.ags import Catalog as AGSCatalog
 from .manage import AGSAdministration
 from .manage._services import Services
 


### PR DESCRIPTION
I'm not sure if this is correct usage, but I had to change some import statements for the following to work on `py 3.5.0`:
```py
>>> import sys
>>> sys.path.insert(0, r"c:/git/arcrest/src")
>>> import _meteor
>>> con = _meteor.Connection("www.arcgis.com")
>>> con.baseUrl
'www.arcgis.com'
```
