### PR TITLE
Fix issue #282 - "KeyError: 'http'" exception

### DIFF
--- a/src/arcrest/manageorg/_portals.py
+++ b/src/arcrest/manageorg/_portals.py
@@ -978,34 +978,40 @@ class Portal(BaseAGOLClass):
                      securityHandler=self._securityHandler,
                      proxy_url=self._proxy_url,
                      proxy_port=self._proxy_port)
-    #----------------------------------------------------------------------
+    # ---------------------------------------------------------------------
+
     @property
     def featureServers(self):
         """gets the hosting feature AGS Server"""
-        services = []
         if self.urls == {}:
             return {}
-        urls = self.urls
-        if 'https' in urls['urls']['features']:
-            res = urls['urls']['features']['https']
+
+        featuresUrls = self.urls['urls']['features']
+        if 'https' in featuresUrls:
+            res = featuresUrls['https']
+        elif 'http' in featuresUrls:
+            res = featuresUrls['http']
         else:
-            res = urls['urls']['features']['http']
-        for https in res:
+            return None
+
+        services = []
+        for urlHost in res:
             if self.isPortal:
-                url = "%s/admin" % https
-                services.append(AGSAdministration(url=url,
-                                                  securityHandler=self._securityHandler,
-                                                  proxy_url=self._proxy_url,
-                                                  proxy_port=self._proxy_port)
-                                )
+                services.append(AGSAdministration(
+                    url='%s/admin' % urlHost,
+                    securityHandler=self._securityHandler,
+                    proxy_url=self._proxy_url,
+                    proxy_port=self._proxy_port))
             else:
-                url = "https://%s/%s/ArcGIS/admin" % (https, self.portalId)
-                services.append(Services(url=url,
-                                         securityHandler=self._securityHandler,
-                                         proxy_url=self._proxy_url,
-                                         proxy_port=self._proxy_port))
+                services.append(Services(
+                    url='https://%s/%s/ArcGIS/admin' % (urlHost, self.portalId),
+                    securityHandler=self._securityHandler,
+                    proxy_url=self._proxy_url,
+                    proxy_port=self._proxy_port))
+
         return services
-    #----------------------------------------------------------------------
+    # ---------------------------------------------------------------------
+
     @property
     def tileServers(self):
         """


### PR DESCRIPTION
### TL;DR
Check for `'http'` key and return `None` if not found.  Also removed some redundancies and improved readability.

Resolves #282: Mysterious "'http'" printed for unknown reason

### Details
When running my program, the message `'http'` appears in the output with no apparent source at first.  After debugging, I found it was an exception being caught on [line 336 of `arcresthelper.securityhandlerhelper.securityhandlerhelper.__init__()`](https://github.com/Esri/ArcREST/blob/master/src/arcresthelper/securityhandlerhelper.py#L336).  Commenting out this `except` block, I found that this exception was being thrown:

```python
arcresthelper.common.ArcRestHelperError: {
'function': 'securityhandlerhelper_init', 
'line': 'line 298', 
'synerror': "KeyError: 'http'", 
'filename': '/…/ArcREST/src/arcresthelper/securityhandlerhelper.py'}
```

[Line 298](https://github.com/Esri/ArcREST/blob/master/src/arcresthelper/securityhandlerhelper.py#L298) contains a call to `arcrest.manageorg._portals.Portal.featureServers()`, which on [line 992 of that file](https://github.com/Esri/ArcREST/blob/master/src/arcrest/manageorg/_portals.py#L992), attempts to access the `'http'` key without checking for it first:

```python
            res = urls['urls']['features']['http']
```

The code in `Portal.featureServers()` is only called by `securityhandlerhelper.__init__()`, which checks to see whether the return value is `None` before using it.  A safe way to prevent the exception is to check for the `'http'` key with a conditional before using it and return `None` if that fails.

I also removed some repeated code, since that's a common place for mistakes to appear later, and reorganized and reformatted this method to improve readability.
