### PR TITLE
Handle servers with no folders except root

### DIFF
--- a/src/arcrest/ags/server.py
+++ b/src/arcrest/ags/server.py
@@ -99,6 +99,9 @@ class Server(BaseAGSServer):
             if k == 'folders':
                 v.insert(0, 'root')
                 setattr(self, "_"+ k, v)
+                
+        if self._folders == None:
+            setattr(self, "_folders", ['root'])
     #----------------------------------------------------------------------
     @property
     def root(self):
@@ -247,4 +250,3 @@ class Server(BaseAGSServer):
                 self._currentFolder = value
                 self._location = self.root
             self.__init(folder=value)
-


### PR DESCRIPTION
Using the ArcRest library, I ran into an issue where a server had no folders, but many services at the root level. This caused the _folders attribute to be set to None rather than an empty array, or an array with ['root']. Having the attribute folders set to None (despite a successful call) throws  exceptions in various cases where the code expects folders to be iterable (for example, the currentFolder setter). 
