### PR TITLE
Corrected oidName to provide variable content without quotes.

### DIFF
--- a/src/arcresthelper/featureservicetools.py
+++ b/src/arcresthelper/featureservicetools.py
@@ -493,7 +493,7 @@ class featureservicetools(securityhandlerhelper):
             if chunksize > 0:
                 fc = os.path.basename(pathToFeatureClass)
                 inDesc = arcpy.Describe(pathToFeatureClass)
-                oidName = arcpy.AddFieldDelimiters(pathToFeatureClass,inDesc.oidFieldName)
+                oidName = inDesc.oidFieldName
 
                 arr = arcpy.da.FeatureClassToNumPyArray(pathToFeatureClass, (oidName))
                 syncSoFar = 0


### PR DESCRIPTION
The line: arcpy.da.FeatureClassToNumPyArray(pathToFeatureClass, (oidName)) failed when
using an oidName that included quotation marks embedded in the string oidName (generated by AddFieldDelimiters on line 496).  Changed the code to provide a correct oidName.