### PR TITLE
Update arcrest.ags.server._validateurl() to Support Compound Web Context Names

### DIFF
--- a/src/arcrest/ags/server.py
+++ b/src/arcrest/ags/server.py
@@ -64,6 +64,9 @@ class Server(BaseAGSServer):
             if any(i in parts for i in url_types):
                 while parts.pop() not in url_types:
                     next
+            elif "services" in parts:
+                while parts.pop() not in "services":
+                    next
             path = "/".join(parts)
         else:
             path = "arcgis"

--- a/src/arcrest/ags/server.py
+++ b/src/arcrest/ags/server.py
@@ -57,13 +57,18 @@ class Server(BaseAGSServer):
     def _validateurl(self, url):
         """assembles the server url"""
         parsed = urlparse(url)
-        parts = parsed.path[1:].split('/')
-        if len(parts) == 0:
-            self._adminUrl = "%s://%s/arcgis/admin" % (parsed.scheme, parsed.netloc)
-            return "%s://%s/arcgis/rest/services" % (parsed.scheme, parsed.netloc)
-        elif len(parts) > 0:
-            self._adminUrl = "%s://%s/%s/admin" % (parsed.scheme, parsed.netloc, parts[0])
-            return "%s://%s/%s/rest/services" % (parsed.scheme, parsed.netloc, parts[0])
+        path = parsed.path.strip("/")
+        if path:
+            parts = path.split("/")
+            url_types = ("admin", "manager", "rest")
+            if any(i in parts for i in url_types):
+                while parts.pop() not in url_types:
+                    next
+            path = "/".join(parts)
+        else:
+            path = "arcgis"
+        self._adminUrl = "%s://%s/%s/admin" % (parsed.scheme, parsed.netloc, path)
+        return "%s://%s/%s/rest/services" % (parsed.scheme, parsed.netloc, path)
     #----------------------------------------------------------------------
     def __init(self, folder='root'):
         """loads the property data into the class"""


### PR DESCRIPTION
Update creates support for compound web context names.  Additionally, SOAP-based URLs are supported, i.e., a SOAP-based URL will be validated to the corresponding REST-based URL for the server instance.