### PR TITLE
Keep featureservicetools from returning ags object

### DIFF
--- a/src/arcrest/agol/services.py
+++ b/src/arcrest/agol/services.py
@@ -1986,7 +1986,7 @@ class FeatureLayer(abstract.BaseAGOLClass):
                path to exported feature class or fgdb (as list)
         """
         if self.hasAttachments and \
-           self.parentLayer.syncEnabled:
+           self.parentLayer != None and self.parentLayer.syncEnabled:
             return self.parentLayer.createReplica(replicaName="fgdb_dump",
                                                   layers="%s" % self.id,
                                                   attachmentsSyncDirection="upload",
@@ -1995,7 +1995,7 @@ class FeatureLayer(abstract.BaseAGOLClass):
                                                   returnAttachments=includeAttachments,
                                                   out_path=out_path)[0]
         elif self.hasAttachments == False and \
-             self.parentLayer.syncEnabled:
+             self.parentLayer != None and self.parentLayer.syncEnabled:
             return self.parentLayer.createReplica(replicaName="fgdb_dump",
                                                   layers="%s" % self.id,
                                                   attachmentsSyncDirection="upload",
@@ -2020,14 +2020,15 @@ class FeatureLayer(abstract.BaseAGOLClass):
             chunks = self._chunks(OIDS, bins)
             for chunk in chunks:
                 chunk.sort()
-                sql = "%s >= %s and %s <= %s" % (OIDField, chunk[0],
-                                                 OIDField, chunk[len(chunk) -1])
-                temp_base = "a" + uuid.uuid4().get_hex()[:6] + "a"
-                temp_fc = r"%s\%s" % (scratchGDB(), temp_base)
-                temp_fc = self.query(where=sql,
-                                     returnFeatureClass=True,
-                                     out_fc=temp_fc)
-                result_features.append(temp_fc)
+                if len(chunk) > 0:
+                    sql = "%s >= %s and %s <= %s" % (OIDField, chunk[0],
+                                                     OIDField, chunk[len(chunk) -1])
+                    temp_base = "a" + uuid.uuid4().get_hex()[:6] + "a"
+                    temp_fc = r"%s\%s" % (scratchGDB(), temp_base)
+                    temp_fc = self.query(where=sql,
+                                         returnFeatureClass=True,
+                                         out_fc=temp_fc)
+                    result_features.append(temp_fc)
             return merge_feature_class(merges=result_features,
                                        out_fc=out_path)
     #----------------------------------------------------------------------

--- a/src/arcresthelper/featureservicetools.py
+++ b/src/arcresthelper/featureservicetools.py
@@ -336,13 +336,10 @@ class featureservicetools(securityhandlerhelper):
                 if returnURLOnly:
                     return item.url
                 else:
-                    fs = arcrest.agol.FeatureService(
-                       url=item.url,
-                       securityHandler=self._securityHandler)
-                    if fs.layers is None or len(fs.layers) == 0 :
-                        fs = arcrest.ags.FeatureService(
-                           url=item.url)
-                    return fs
+                    if hasattr(self._securityHandler, 'is_portal'):
+                        if self._securityHandler.is_portal:
+                            return arcrest.ags.FeatureService(url=item.url)
+                    return arcrest.agol.FeatureService(url=item.url,securityHandler=self._securityHandler)
             return None
 
         except:


### PR DESCRIPTION
Modify featureservicetools.py to use the is_portal member of the security handler instead of the absence of layers in the feature service to decide to return an ags.FeatureService. I'm a little less confident of this as I'm not using portal at all. Was having problems with getting the ags object when working with empty agol feature services.